### PR TITLE
Changed up arrow function to rotate, fixed bug in backL. Closes #17

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ interface IAppProps {
   rotate: () => void;
 }
 
-class App extends React.Component<IAppProps> {  
+class App extends React.Component<IAppProps> {
   public render() {
     return (
       <div className={css(styles.app)}>
@@ -27,11 +27,11 @@ class App extends React.Component<IAppProps> {
   }
 
   @keydown(Keys.LEFT, Keys.RIGHT, Keys.UP, Keys.DOWN, Keys.R)
-  private submit(event: any){ 
+  private submit(event: any){
     switch(event.key){
       case 'ArrowLeft':   return this.props.left();
       case 'ArrowRight':  return this.props.right();
-      case 'ArrowUp':     return this.props.up();
+      case 'ArrowUp':     return this.props.rotate();
       case 'ArrowDown':   return this.props.down();
       case 'r':           return this.props.rotate();
     }

--- a/src/components/tetromino/index.tsx
+++ b/src/components/tetromino/index.tsx
@@ -35,7 +35,7 @@ interface ICoordinate {
 const tetrominoCoordinates: Record<Tetromino, ICoordinate[][]> = {
     backL: [
         [{ x: 0, y: 0 }, ..._.range(3).map(x => ({ x, y: 1 }))],
-        [{ x: 2, y: 0 }, ..._.range(3).map(y => ({ x: 1, y }))],
+        [{ x: 1, y: 0 }, ..._.range(3).map(y => ({ x: 0, y }))],
         [{ x: 2, y: 2 }, ..._.range(3).map(x => ({ x, y: 1 }))],
         [{ x: 0, y: 2 }, ..._.range(3).map(y => ({ x: 1, y }))]
     ],


### PR DESCRIPTION
The bug:
Orientations 0, 2, and 3 of backL were all touching the left side of the grid when moving left, whereas orientation 1 would always leave a 1 block gap. This was because the definition of the orientation was in the centre two columns of the 4x4 grid, while all other definitions (of all the shapes) are against the left edge, and so movement was coded assuming the shapes would be against that edge. It is now against that edge, and working properly while rotated.